### PR TITLE
Use immutable.js for storage backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/secp256k1": "^4.0.3",
     "bech32": "^2.0.0",
     "elliptic": "^6.5.4",
+    "immutable": "^4.1.0",
     "process": "^0.11.10",
     "secp256k1": "^4.0.3",
     "synchronized-promise": "^0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3881,6 +3881,11 @@ ignore@^5.1.1, ignore@^5.1.8, ignore@^5.2.0:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
+immutable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
+  integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz"


### PR DESCRIPTION
This replaces the backend's storage with Immutable.Map instead of Map<string, string> -- this helps with state snapshots.