### PR TITLE
Queue tests and fix db_next

### DIFF
--- a/src/backend/storage.ts
+++ b/src/backend/storage.ts
@@ -1,5 +1,5 @@
 import { fromBase64, toBase64 } from '@cosmjs/encoding';
-import { compare, toNumber } from '../helpers/byte-array';
+import { compare, toByteArray, toNumber } from '../helpers/byte-array';
 import Immutable from 'immutable';
 import { MAX_LENGTH_DB_KEY } from '../instance';
 
@@ -31,7 +31,7 @@ export enum Order {
 export interface IIterStorage extends IStorage {
   all(iterator_id: Uint8Array): Array<Record>;
 
-  scan(start: Uint8Array, end: Uint8Array, order: Order): number;
+  scan(start: Uint8Array | null, end: Uint8Array | null, order: Order): Uint8Array;
   next(iterator_id: Uint8Array): Record | null;
 }
 
@@ -108,7 +108,7 @@ export class BasicKVIterStorage extends BasicKVStorage implements IIterStorage {
     return record;
   }
 
-  scan(start: Uint8Array, end: Uint8Array, order: Order): number {
+  scan(start: Uint8Array | null, end: Uint8Array | null, order: Order): Uint8Array {
     if (!(order in Order)) {
       throw new Error(`Invalid order value ${order}.`);
     }
@@ -116,15 +116,15 @@ export class BasicKVIterStorage extends BasicKVStorage implements IIterStorage {
     const newId = this.iterators.size + 1;
 
     // if start > end, this represents an empty range
-    if (start.length && end.length && compare(start, end) === 1) {
+    if (start?.length && end?.length && compare(start, end) === 1) {
       this.iterators.set(newId, { data: [], position: 0 });
-      return newId;
+      return toByteArray(newId);
     }
 
     let data: Record[] = [];
     for (const key of this.dict.keys()) {
-      if (start.length && compare(start, fromBase64(key)) === 1) continue;
-      if (end.length && compare(fromBase64(key), end) > -1) break;
+      if (start?.length && compare(start, fromBase64(key)) === 1) continue;
+      if (end?.length && compare(fromBase64(key), end) > -1) break;
 
       data.push({ key: fromBase64(key), value: this.get(fromBase64(key))! });
     }
@@ -134,6 +134,6 @@ export class BasicKVIterStorage extends BasicKVStorage implements IIterStorage {
     }
 
     this.iterators.set(newId, { data, position: 0 });
-    return newId;
+    return toByteArray(newId);
   }
 }

--- a/src/backend/storage.ts
+++ b/src/backend/storage.ts
@@ -1,5 +1,5 @@
 import { fromBase64, toBase64 } from '@cosmjs/encoding';
-import { compare } from '../helpers/byte-array';
+import { compare, toNumber } from '../helpers/byte-array';
 import Immutable from 'immutable';
 import { MAX_LENGTH_DB_KEY } from '../instance';
 
@@ -29,10 +29,10 @@ export enum Order {
 }
 
 export interface IIterStorage extends IStorage {
-  all(iterator_id: number): Array<Record>;
+  all(iterator_id: Uint8Array): Array<Record>;
 
-  scan(start: Uint8Array | null, end: Uint8Array | null, order: Order): number; // Uint32
-  next(iterator_id: number /* Uint32 */): Record | null;
+  scan(start: Uint8Array, end: Uint8Array, order: Order): number;
+  next(iterator_id: Uint8Array): Record | null;
 }
 
 export class BasicKVStorage implements IStorage {
@@ -75,7 +75,7 @@ export class BasicKVIterStorage extends BasicKVStorage implements IIterStorage {
     super();
   }
 
-  all(iterator_id: number): Array<Record> {
+  all(iterator_id: Uint8Array): Array<Record> {
     const out: Array<Record> = [];
     let condition = true;
     while (condition) {
@@ -94,10 +94,10 @@ export class BasicKVIterStorage extends BasicKVStorage implements IIterStorage {
   // Ownership of the result region is transferred to the contract.
   // The KV region uses the format value || key || keylen, where keylen is a fixed size big endian u32 value.
   // An empty key (i.e. KV region ends with \0\0\0\0) means no more element, no matter what the value is.
-  next(iterator_id: number): Record | null {
-    const iter = this.iterators.get(iterator_id);
+  next(iterator_id: Uint8Array): Record | null {
+    const iter = this.iterators.get(toNumber(iterator_id));
     if (iter === undefined) {
-      throw new Error(`Iterator ${iterator_id} not found.`);
+      throw new Error(`Iterator not found.`);
     }
     const record = iter.data[iter.position];
     if (!record) {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -16,7 +16,7 @@ export class VMInstance {
   public instance?: WebAssembly.Instance;
   public bech32: BechLib;
 
-  constructor(public backend: IBackend) {
+  constructor(public backend: IBackend, public readonly gasLimit?: number | undefined) {
     this.bech32 = bech32;
   }
 
@@ -49,6 +49,10 @@ export class VMInstance {
     if (!this.instance)
       throw new Error('Please init instance before using methods');
     return this.instance!.exports;
+  }
+
+  public get remainingGas() {
+    return this.gasLimit; // TODO: implement
   }
 
   public allocate(size: number): Region {
@@ -136,7 +140,6 @@ export class VMInstance {
   }
 
   db_next(iterator_id: number): number {
-    console.log(iterator_id)
     return this.do_db_next(iterator_id).ptr;
   }
 

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -261,9 +261,7 @@ export class VMInstance {
   }
 
   do_db_scan(start: Region, end: Region, order: number): Region {
-    const iterId = this.backend.storage.scan(start.data, end.data, order);
-    const iterIdBytes = toByteArray(iterId);
-
+    const iterIdBytes = this.backend.storage.scan(start.data, end.data, order);
     let region = this.allocate(iterIdBytes.length);
     region.write(iterIdBytes);
     return region;

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -139,7 +139,8 @@ export class VMInstance {
     return this.do_db_scan(start, end, order).ptr;
   }
 
-  db_next(iterator_id: number): number {
+  db_next(iterator_id_ptr: number): number {
+    let iterator_id = this.region(iterator_id_ptr);
     return this.do_db_next(iterator_id).ptr;
   }
 
@@ -268,8 +269,8 @@ export class VMInstance {
     return region;
   }
 
-  do_db_next(iterator_id: number): Region {
-    const record: Record | null = this.backend.storage.next(iterator_id);
+  do_db_next(iterator_id: Region): Region {
+    const record: Record | null = this.backend.storage.next(iterator_id.data);
     let result;
     if (record === null) {
       result = this.region(0);

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -729,13 +729,13 @@ describe('db_scan', () => {
     const id = toNumber(idRegion.data);
     expect(id).toBe(1);
 
-    let item = vm.do_db_next(id);
+    let item = vm.do_db_next(idRegion);
     expectToBeKvp(item, testData.KEY1, testData.VALUE1);
 
-    item = vm.do_db_next(id);
+    item = vm.do_db_next(idRegion);
     expectToBeKvp(item, testData.KEY2, testData.VALUE2);
 
-    item = vm.do_db_next(id);
+    item = vm.do_db_next(idRegion);
     expect(item.ptr).toBe(0);
   });
 
@@ -744,13 +744,13 @@ describe('db_scan', () => {
     const id = toNumber(idRegion.data);
     expect(id).toBe(1);
 
-    let item = vm.do_db_next(id);
+    let item = vm.do_db_next(idRegion);
     expectToBeKvp(item, testData.KEY2, testData.VALUE2);
 
-    item = vm.do_db_next(id);
+    item = vm.do_db_next(idRegion);
     expectToBeKvp(item, testData.KEY1, testData.VALUE1);
 
-    item = vm.do_db_next(id);
+    item = vm.do_db_next(idRegion);
     expect(item.ptr).toBe(0);
   });
 
@@ -762,10 +762,10 @@ describe('db_scan', () => {
     const id = toNumber(idRegion.data);
     expect(id).toBe(1);
 
-    let item = vm.do_db_next(id);
+    let item = vm.do_db_next(idRegion);
     expectToBeKvp(item, testData.KEY1, testData.VALUE1);
 
-    item = vm.do_db_next(id);
+    item = vm.do_db_next(idRegion);
     expect(item.ptr).toBe(0);
   });
 
@@ -777,10 +777,10 @@ describe('db_scan', () => {
     const id = toNumber(idRegion.data);
     expect(id).toBe(1);
 
-    let item = vm.do_db_next(id);
+    let item = vm.do_db_next(idRegion);
     expectToBeKvp(item, testData.KEY2, testData.VALUE2);
 
-    item = vm.do_db_next(id);
+    item = vm.do_db_next(idRegion);
     expect(item.ptr).toBe(0);
   });
 
@@ -793,11 +793,11 @@ describe('db_scan', () => {
     const id2 = toNumber(idRegion2.data);
     expect(id2).toBe(2);
 
-    expectToBeKvp(vm.do_db_next(id1), testData.KEY1, testData.VALUE1); // first item, first iterator
-    expectToBeKvp(vm.do_db_next(id1), testData.KEY2, testData.VALUE2); // second item, first iterator
-    expectToBeKvp(vm.do_db_next(id2), testData.KEY2, testData.VALUE2); // first item, second iterator
-    expect(vm.do_db_next(id1).ptr).toBe(0);                            // end, first iterator
-    expectToBeKvp(vm.do_db_next(id2), testData.KEY1, testData.VALUE1); // second item, second iterator
+    expectToBeKvp(vm.do_db_next(idRegion1), testData.KEY1, testData.VALUE1); // first item, first iterator
+    expectToBeKvp(vm.do_db_next(idRegion1), testData.KEY2, testData.VALUE2); // second item, first iterator
+    expectToBeKvp(vm.do_db_next(idRegion2), testData.KEY2, testData.VALUE2); // first item, second iterator
+    expect(vm.do_db_next(idRegion1).ptr).toBe(0);                            // end, first iterator
+    expectToBeKvp(vm.do_db_next(idRegion2), testData.KEY1, testData.VALUE1); // second item, second iterator
   });
 
   it('fails for invalid order value', () => {
@@ -813,18 +813,17 @@ describe('do_db_next', () => {
 
   it('works', () => {
     const idRegion = vm.do_db_scan(vm.allocate(0), vm.allocate(0), Order.Ascending);
-    const id = toNumber(idRegion.data);
 
-    expectToBeKvp(vm.do_db_next(id), testData.KEY1, testData.VALUE1);
-    expectToBeKvp(vm.do_db_next(id), testData.KEY2, testData.VALUE2);
-    expect(vm.do_db_next(id).ptr).toBe(0);
+    expectToBeKvp(vm.do_db_next(idRegion), testData.KEY1, testData.VALUE1);
+    expectToBeKvp(vm.do_db_next(idRegion), testData.KEY2, testData.VALUE2);
+    expect(vm.do_db_next(idRegion).ptr).toBe(0);
   });
 
   it('fails for non existent id', () => {
     try {
-      vm.do_db_next(0);
+      vm.do_db_next(vm.region(0));
     } catch (e) {
-      expect(e).toEqual(new Error('Iterator 0 not found.'));
+      expect(e).toEqual(new Error('Iterator not found.'));
     }
   });
 });

--- a/test/integration/cyberpunk.test.ts
+++ b/test/integration/cyberpunk.test.ts
@@ -43,13 +43,11 @@ describe('cyberpunk', () => {
   // port of https://github.com/CosmWasm/cosmwasm/blob/f6a0485088f1084379a5655bcc2956526290c09f/contracts/cyberpunk/tests/integration.rs#L30
   it.skip('execute_argon2', async () => { // gas limit not implemented
     // Arrange
-    // TODO: implement gas limit on VM
-    // const vm = new VMInstance(backend, { gasLimit: 100_000_000_000_000 })
+    vm = new VMInstance(backend, 100_000_000_000_000); // TODO: implement gas limit on VM
     const initRes = vm.instantiate(mockEnv, mockInfo, {}).json as any;
     expect(initRes.messages.length).toStrictEqual(0);
 
-    // TODO: getGasLeft method
-    // const gasBefore = vm.getGasLeft();
+    const gasBefore = vm.remainingGas;
 
     // Act
     const executeRes = vm.execute(

--- a/test/integration/queue.test.ts
+++ b/test/integration/queue.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'fs';
+import { VMInstance } from "../../src/instance";
+import {
+  BasicBackendApi,
+  BasicKVIterStorage,
+  BasicQuerier,
+  IBackend,
+} from '../../src/backend';
+import { Region } from '../../src/memory';
+import { expectResponseToBeOk, parseBase64Response } from '../common/test-vm';
+
+const wasmBytecode = readFileSync('testdata/v1.1/queue.wasm');
+const backend: IBackend = {
+  backend_api: new BasicBackendApi('terra'),
+  storage: new BasicKVIterStorage(),
+  querier: new BasicQuerier(),
+};
+
+const creator = 'creator';
+const mockContractAddr = 'cosmos2contract';
+
+const mockEnv = {
+  block: {
+    height: 12345,
+    time: '1571797419879305533',
+    chain_id: 'cosmos-testnet-14002',
+  },
+  contract: { address: mockContractAddr }
+};
+
+const mockInfo: { sender: string, funds: { amount: string, denom: string }[] } = {
+  sender: creator,
+  funds: []
+};
+
+let vm: VMInstance;
+describe('hackatom', () => {
+  beforeEach(async () => {
+    vm = new VMInstance(backend, 100_000_000_000_000) // TODO: implement gas limit on VM
+    await vm.build(wasmBytecode);
+  });
+
+  it.skip('instantiate_and_query', async () => {
+    // Arrange
+    const instantiateResponse = vm.instantiate(mockEnv, mockInfo, {});
+    expect((instantiateResponse.json as any).ok.messages.length).toBe(0);
+
+    // Act
+    const countResponse = vm.query(mockEnv, { count: {} });
+    const sumResponse = vm.query(mockEnv, { sum: {} });
+
+    // Assert
+    expectResponseToBeOk(countResponse);
+    expect(parseBase64OkResponse(countResponse)).toEqual({ count: 0 });
+
+    expectResponseToBeOk(sumResponse);
+    expect(parseBase64OkResponse(sumResponse)).toEqual({ sum: 0 });
+  });
+});
+
+// Helpers
+
+function parseBase64OkResponse(region: Region): any {
+  const data = (region.json as { ok: string }).ok;
+  if (!data) {
+    throw new Error(`Response indicates an error state: ${JSON.stringify(region.json)}`)
+  }
+
+  return parseBase64Response(data);
+}

--- a/test/integration/queue.test.ts
+++ b/test/integration/queue.test.ts
@@ -40,7 +40,7 @@ describe('hackatom', () => {
     await vm.build(wasmBytecode);
   });
 
-  it.only('instantiate_and_query', async () => {
+  it.skip('instantiate_and_query', async () => {
     // Arrange
     const instantiateResponse = vm.instantiate(mockEnv, mockInfo, {});
     expect((instantiateResponse.json as any).ok.messages.length).toBe(0);

--- a/test/integration/queue.test.ts
+++ b/test/integration/queue.test.ts
@@ -40,7 +40,7 @@ describe('hackatom', () => {
     await vm.build(wasmBytecode);
   });
 
-  it.skip('instantiate_and_query', async () => {
+  it.only('instantiate_and_query', async () => {
     // Arrange
     const instantiateResponse = vm.instantiate(mockEnv, mockInfo, {});
     expect((instantiateResponse.json as any).ok.messages.length).toBe(0);

--- a/test/integration/queue.test.ts
+++ b/test/integration/queue.test.ts
@@ -34,7 +34,7 @@ const mockInfo: { sender: string, funds: { amount: string, denom: string }[] } =
 };
 
 let vm: VMInstance;
-describe('hackatom', () => {
+describe('queue', () => {
   beforeEach(async () => {
     vm = new VMInstance(backend, 100_000_000_000_000) // TODO: implement gas limit on VM
     await vm.build(wasmBytecode);


### PR DESCRIPTION
This PR fixes a bunch of stuff in storage:
- `next` now takes a `Uint8Array`, as the parameter passed to the `db_next` hook from CosmWasm is by reference (i.e. a pointer)
- `scan` returns a `Uint8Array`, to make it consistent with the other methods

The test still isn't passing due to a separate bug, but I'd like to get these fixes in ASAP.