### PR TITLE
Fix ethereum_signature_verify_works test

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -350,9 +350,6 @@ export class VMInstance {
   // Verifies message hashes against a signature with a public key, using the secp256k1 ECDSA parametrization.
   // Returns 0 on verification success, 1 on verification failure
   do_secp256k1_verify(hash: Region, signature: Region, pubkey: Region): number {
-    console.log(
-        `signature length: ${signature.str.length}, pubkey length: ${pubkey.str.length}, message length: ${hash.str.length}`
-    );
     const isValidSignature = ecdsaVerify(
         signature.data,
         hash.data,

--- a/test/integration/crypto-verify.test.ts
+++ b/test/integration/crypto-verify.test.ts
@@ -115,10 +115,9 @@ describe('crypto-verify', () => {
 
   it('ethereum_signature_verify_works', async () => {
     vm.instantiate(mockEnv, mockInfo, {});
-
     const verify_msg = {
       verify_ethereum_text: {
-        message: convertStringToBase64(testData.ETHEREUM_MESSAGE),
+        message: testData.ETHEREUM_MESSAGE,
         signature: convertHexToBase64(testData.ETHEREUM_SIGNATURE_HEX),
         signer_address: testData.ETHEREUM_SIGNER_ADDRESS,
       }


### PR DESCRIPTION
## Issue
[WL-506](https://terran-one.atlassian.net/browse/WL-506)

## Description
Fixed *ethereum_signature_verify_works* test. The bug was never in the logic, but in the data passed to the contract: message shouldn't have been base64 encoded.

## Test Steps
run `yarn test test/integration/crypto-verify` and assert *ethereum_signature_verify_works* test succeeds (there are still other failing tests as of now)
