### PR TITLE
Add support for saving debugging messages, generic queriers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terran-one/cosmwasm-vm-js",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "license": "MIT",
   "author": "TerranOne",
   "main": "dist/index.js",

--- a/src/backend/backendApi.ts
+++ b/src/backend/backendApi.ts
@@ -29,12 +29,12 @@ export class GasInfo implements IGasInfo {
 }
 
 export interface IBackendApi {
+  bech32_prefix: string;
   canonical_address(human: string): Uint8Array;
-
   human_address(canonical: Uint8Array): string;
 }
 
-export class BasicBackendApi implements BasicBackendApi {
+export class BasicBackendApi implements IBackendApi {
   // public GAS_COST_CANONICALIZE = 55;
   public CANONICAL_LENGTH = 54;
   public EXCESS_PADDING = 6;

--- a/src/backend/storage.ts
+++ b/src/backend/storage.ts
@@ -4,6 +4,7 @@ import Immutable from 'immutable';
 import { MAX_LENGTH_DB_KEY } from '../instance';
 
 export interface IStorage {
+  dict: Immutable.Map<string, string>;
   get(key: Uint8Array): Uint8Array | null;
 
   set(key: Uint8Array, value: Uint8Array): void;
@@ -71,8 +72,8 @@ export class BasicKVStorage implements IStorage {
 }
 
 export class BasicKVIterStorage extends BasicKVStorage implements IIterStorage {
-  constructor(public iterators: Map<number, Iter> = new Map()) {
-    super();
+  constructor(public dict: Immutable.Map<string, string> = Immutable.Map(), public iterators: Map<number, Iter> = new Map()) {
+    super(dict);
   }
 
   all(iterator_id: Uint8Array): Array<Record> {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -12,9 +12,9 @@ export const MAX_LENGTH_CANONICAL_ADDRESS: number = 64;
 export const MAX_LENGTH_HUMAN_ADDRESS: number = 256;
 
 export class VMInstance {
-  public PREFIX: string = 'terra';
   public instance?: WebAssembly.Instance;
   public bech32: BechLib;
+  public debugMsgs: string[] = [];
 
   constructor(public backend: IBackend, public readonly gasLimit?: number | undefined) {
     this.bech32 = bech32;
@@ -336,9 +336,8 @@ export class VMInstance {
       throw new Error('Invalid address.');
     }
 
-    // TODO: Change prefix to be configurable per environment
     const human = this.bech32.encode(
-        this.PREFIX,
+        this.backend.backend_api.bech32_prefix,
         this.bech32.toWords(canonical)
     );
     if (human !== source.str) {
@@ -453,7 +452,7 @@ export class VMInstance {
   }
 
   do_debug(message: Region) {
-    console.log(message.read_str());
+    this.debugMsgs.push(message.read_str());
   }
 
   do_query_chain(request: Region): Region {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -3,7 +3,7 @@ import { bech32, BechLib } from 'bech32';
 import { Region } from './memory';
 import { ecdsaRecover, ecdsaVerify } from 'secp256k1';
 import { IBackend, Record } from './backend';
-import { Env, MessageInfo } from 'types';
+import { Env, MessageInfo } from './types';
 import { toByteArray, toNumber } from './helpers/byte-array';
 
 export const MAX_LENGTH_DB_KEY: number = 64 * 1024;

--- a/test/integration/burner.test.ts
+++ b/test/integration/burner.test.ts
@@ -17,11 +17,17 @@ import {
 import { toAscii } from '@cosmjs/encoding';
 import { Env, MessageInfo } from '../../src/types';
 
+class MockQuerier extends BasicQuerier {
+  handleQuery(request: any): any {
+    return { amount: [{ denom: 'earth', amount: '1000' }] }
+  }
+}
+
 const wasmBytecode = readFileSync('testdata/v1.1/burner.wasm');
 const backend: IBackend = {
   backend_api: new BasicBackendApi('terra'),
   storage: new BasicKVIterStorage(),
-  querier: new BasicQuerier(),
+  querier: new MockQuerier(),
 };
 
 const creator = 'terra1337xewwfv3jdjuz8e0nea9vd8dpugc0k2dcyt3';


### PR DESCRIPTION
We add a new property `debugMsgs: string[]` to `VMInstance`, to which contract calls to `deps.api.debug(...)` will append. Previously, we simply printed the string out to console (which matches the behavior of `cosmwasm-vm-js`); however this is harder to work with for consuming applications like CWSimulate.

The old implementation for `BasicQuerier` was temporary and designed to only handle 1 case (in the tests), this adds generic support for `query_chain`. You must now subclass `BasicQuerier` and supply your own `handleQuery()` function, which will get passed the decoded query request. `BasicQuerier.query_raw()` will delegate and handle the proper encoding of `BasicQuerier.handleQuery()`, which is `toUint8Array({ ok: { ok: toBase64(response) } })`, where `response` is a JSON object containing the query response.

In the future, we will need to provide support for Rust errors, because the `Ok(Ok(response))` corresponds to `SystemResult<ContractResult<Binary>>` (`Binary` is a CosmWasm Rust type that encodes a struct to Base64 strings in JSON).