### PR TITLE
Target ES6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,7 @@
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "target": "esnext",
+    "target": "es6",
     "paths": {
       "*": [
         "src/*"


### PR DESCRIPTION
Currently, library targets ESNext, which can and will change. We should specify a concrete JS version for consistency.